### PR TITLE
feat: add sessions & cookies middleware & provide to main app controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+  include ActionController::Cookies
+
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,18 +22,13 @@ module AfyanetRails
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
-
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    
+    # Configure Cookies and Sessions for storing session data, and authorization & authentication
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
+
+    # This middleware provides application security, accepting cookies/requests that only come from our domain
+    config.action_dispatch.cookies_same_site_protection = :strict
   end
 end


### PR DESCRIPTION
- Add cookies and sessions middleware in config/application.rb file on lines 28 & 29
- Add security allowing cookies/requests only from our domain in config/application.rb file on line 32
- include the Cookies in application controller (app/controllers/application_controller.rb) on line 2