### PR TITLE
fix: add missing keyword marking end of Doctors controller

### DIFF
--- a/app/controllers/doctors_controller.rb
+++ b/app/controllers/doctors_controller.rb
@@ -14,5 +14,6 @@ class DoctorsController < ApplicationController
   def doctor_params 
     params.permit(:first_name, :last_name, :email, :phone_number, :password, :password_confirmation)
   end
-  
+
+end
 


### PR DESCRIPTION
- add the 'end' keyword that was missing to mark the close of the doctors controller class to line 18 of app/controllers/doctors_controller.rb file. 